### PR TITLE
Add a service to handle batch searches over HTTP POST

### DIFF
--- a/api/client.yaml
+++ b/api/client.yaml
@@ -741,6 +741,26 @@ paths:
               schema:
                 $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
 
+  /search/batch:
+    post:
+      description: Search, in a batch
+      operationId: searchBatch
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                csvFile:
+                  type: string
+                  format: binary
+        required: true
+      responses:
+        "201":
+          description: SDNs returned from a search
+        "400":
+          description: Error occurred, see response body.
+
   # Downloads endpoint
   /downloads:
     get:

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -921,6 +921,25 @@ paths:
       summary: Search US CSL
       tags:
       - Watchman
+  /search/batch:
+    post:
+      description: Search, in a batch
+      operationId: searchBatch
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                csvFile:
+                  type: string
+                  format: binary
+        required: true
+      responses:
+        "201":
+          description: SDNs returned from a search
+        "400":
+          description: Error occurred, see response body.
   /downloads:
     get:
       description: Return list of recent downloads of list data.

--- a/cmd/cc_batchsearch/main.go
+++ b/cmd/cc_batchsearch/main.go
@@ -9,42 +9,30 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
 
-	"github.com/antihax/optional"
+	"github.com/moov-io/base/log"
+
 	"github.com/moov-io/watchman"
 	moov "github.com/moov-io/watchman/client"
 	"github.com/moov-io/watchman/cmd/internal"
-	"go4.org/syncutil"
 )
 
 var (
-	flagApiAddress   = flag.String("address", internal.DefaultApiAddress, "Moov API address")
-	flagLocal        = flag.Bool("local", true, "Use local HTTP addresses")
-	flagThreshold    = flag.Float64("threshold", 0.99, "Minimum match percentage required for blocking")
-	flagMinNameScore = flag.Float64("min-match", 0.90, "How close must names match")
-	flagFile         = flag.String("file", "", "Filepath to file with names to check")
-	flagSdnType      = flag.String("sdn-type", "individual", "sdnType query param")
-	flagRequestID    = flag.String("request-id", "", "Override what is set for the X-Request-ID HTTP header")
-	flagVerbose      = flag.Bool("v", false, "Enable detailed logging")
-	flagWorkers      = flag.Int("workers", runtime.NumCPU(), "How many tasks to run concurrently")
-	flagWriteFile    = flag.Bool("write", false, "Write results to file, name will be <file>_output.csv")
+	flagApiAddress = flag.String("address", internal.DefaultApiAddress, "Moov API address")
+	flagLocal      = flag.Bool("local", true, "Use local HTTP addresses")
+	flagFile       = flag.String("file", "", "Filepath to file with names to check")
+	flagWriteFile  = flag.Bool("write", false, "Write results to file, name will be <file>_output.csv")
 )
 
 func main() {
 	flag.Parse()
-
-	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lmicroseconds | log.Lshortfile)
-	log.Printf("Starting moov/batchsearch %s", watchman.Version)
+	log := log.NewDefaultLogger()
+	log.Info().Logf("Starting moov/batchsearch %s", watchman.Version)
 
 	conf := internal.Config(*flagApiAddress, *flagLocal)
-	log.Printf("[INFO] using %s for API address", conf.BasePath)
+	log.Info().Logf("[INFO] using %s for API address", conf.BasePath)
 
 	// Setup API client
 	api, ctx := moov.NewAPIClient(conf), context.TODO()
@@ -52,19 +40,29 @@ func main() {
 
 	// Ping
 	if err := ping(ctx, api); err != nil {
-		log.Fatalf("[FAILURE] ping Sanctions Search: %v", err)
+		log.Fatal().LogErrorf("[FAILURE] ping Sanctions Search: %v", err)
 	} else {
-		log.Println("[SUCCESS] ping")
+		log.Info().Log("[SUCCESS] ping")
 	}
 
 	if path := *flagFile; path != "" {
 		rows, err := readRows(path)
 		if err != nil {
-			log.Fatalf("[FAILURE] %v", err)
+			log.Fatal().LogErrorf("[FAILURE] %v", err)
 		}
-		if n := processRows(rows, *flagThreshold, api); n == Failure {
-			os.Exit(int(n))
+
+		result, err := internal.ProcessRows(rows, api, log)
+
+		if err != nil {
+			log.Fatal().LogErrorf("[FAILURE] %v", err)
 		}
+
+		if *flagWriteFile {
+			if err := writeResultsToFile(result); err != nil {
+				log.Fatal().LogErrorf("[FATAL] problem writing to file: %v", err)
+			}
+		}
+
 	}
 }
 
@@ -84,87 +82,6 @@ var (
 	Success int64 = 0
 	Failure int64 = 1
 )
-
-type ChanResult struct {
-	Index int
-	Value string
-}
-
-func processRows(rows []string, threshold float64, api *moov.APIClient) int64 {
-	// First row is headers, store them
-	headings := rows[0]
-	rows = rows[1:]
-
-	var wg sync.WaitGroup
-
-	var exitCode int64 // must be protected with atomic calls
-	markFailure := func() {
-		atomic.CompareAndSwapInt64(&exitCode, Success, Failure) // set Failure as exit code
-	}
-
-	workers := syncutil.NewGate(*flagWorkers)
-	resultsChan := make(chan ChanResult, len(rows))
-	output := make([]string, len(rows)+1) // +1 for header row
-
-	for i, row := range rows {
-		wg.Add(1)
-		workers.Start()
-		go func(i int, row string) {
-			defer workers.Done()
-			defer wg.Done()
-
-			// Compose name from fixed columns - make smarter, later
-			cols := strings.Split(row, ",")
-			name := fmt.Sprintf("%s, %s", cols[2], cols[1])
-
-			if result, err := searchByName(api, name); err != nil {
-				markFailure()
-				log.Printf("[FATAL] problem searching for '%s': %v", name, err)
-			} else {
-				if result.IsSet {
-					if *flagVerbose {
-						log.Print(newSearchResultString(result, name))
-					}
-					resultsChan <- ChanResult{Value: newSearchResultRecord(result, row), Index: i}
-
-				} else {
-					if *flagVerbose {
-						log.Printf("[RESULT] no hits for %s", name)
-					}
-					resultsChan <- ChanResult{Value: newSearchResultClearRecord(result, row), Index: i}
-				}
-			}
-		}(i, row)
-	}
-
-	go func() {
-		wg.Wait()
-		close(resultsChan)
-	}()
-
-	output[0] = writeHeadings(headings)
-	for r := range resultsChan {
-		output[r.Index+1] = r.Value // +1 for header row
-	}
-
-	if *flagVerbose {
-		fmt.Print("\n\n")
-		for i := range output {
-			fmt.Printf("%s\n", output[i])
-		}
-		fmt.Print("\n\n")
-	}
-
-	if *flagWriteFile {
-		if err := writeResultsToFile(output); err != nil {
-			log.Printf("[FATAL] problem writing to file: %v", err)
-		}
-	}
-
-	log.Printf("[SUCCESS] %d checks complete\n", len(rows))
-
-	return exitCode
-}
 
 func readRows(path string) ([]string, error) {
 	fd, err := os.Open(path)
@@ -189,149 +106,4 @@ func readRows(path string) ([]string, error) {
 func writeResultsToFile(results []string) error {
 	output_filename := strings.Split(*flagFile, ".")[0] + "_output.csv"
 	return os.WriteFile(output_filename, []byte(strings.Join(results, "\n")), 0644)
-}
-
-func getNoun(score float64) string {
-	if score < 0.0 {
-		return "Clear"
-	}
-	if score >= *flagThreshold {
-		return "MATCH"
-	}
-	return "Hit"
-}
-
-func newSearchResultString(result moov.SearchResult, searched_name string) string {
-	return fmt.Sprintf(
-		"[RESULT] found %s for %s: SdnName=%s; EntityID=%s; Type=%s; Score=%.2f; Programs=%v; Remarks=%s; Timestamp=%s",
-		getNoun(result.Score),
-		searched_name,
-		*result.SdnName,
-		*result.EntityID,
-		result.Type,
-		result.Score,
-		result.Programs,
-		result.Remarks,
-		time.Now().Format(time.RFC3339),
-	)
-}
-
-func newSearchResultRecord(result moov.SearchResult, input_row string) string {
-	sdn_name_no_comma := *result.SdnName
-	if strings.Contains(*result.SdnName, ",") {
-		sdn_name_parts := strings.Split(*result.SdnName, ",")
-		sdn_name_no_comma = fmt.Sprintf("%s %s", sdn_name_parts[1], sdn_name_parts[0])
-	}
-
-	return fmt.Sprintf(
-		"%s,%s,%s,%s,%.2f,%s,%s",
-		strings.TrimRight(input_row, ","),
-		getNoun(result.Score),
-		sdn_name_no_comma,
-		*result.EntityID,
-		result.Score,
-		result.Programs,
-		time.Now().Format(time.RFC3339),
-	)
-}
-
-func newSearchResultClearRecord(result moov.SearchResult, searched_name string) string {
-	return fmt.Sprintf(
-		"%s,%s,,,,,%s",
-		strings.TrimRight(searched_name, ","),
-		getNoun(result.Score),
-		time.Now().Format(time.RFC3339),
-	)
-}
-
-func writeHeadings(original_headings string) string {
-	return fmt.Sprintf(
-		"%s,%s,%s,%s,%s,%s,%s",
-		strings.TrimRight(original_headings, ","),
-		"Result",
-		"SdnName",
-		"EntityID",
-		"Score",
-		"Programs",
-		"Timestamp",
-	)
-}
-
-func newSearchResult(query_result moov.OfacSdn, entity_id string, score float64) moov.SearchResult {
-	return moov.SearchResult{
-		IsSet:    true,
-		EntityID: &entity_id,
-		SdnName:  &query_result.SdnName,
-		Type:     query_result.SdnType,
-		Score:    score,
-		Programs: query_result.Programs,
-	}
-}
-
-/*
- * Search OFAC data for given name.
- * If no SDN but altNames, get data for each altName's EntityID.
- *
- * return SearchResult struct with: EntityID, SdnName, Type, Score, Programs
- */
-func searchByName(api *moov.APIClient, name string) (moov.SearchResult, error) {
-	opts := &moov.SearchOpts{
-		Limit:      optional.NewInt32(1),
-		Name:       optional.NewString(name),
-		MinMatch:   optional.NewFloat32(float32(*flagMinNameScore)),
-		SdnType:    optional.NewInterface(*flagSdnType),
-		XRequestID: optional.NewString(*flagRequestID),
-	}
-	empty_result := moov.SearchResult{
-		IsSet:    false,
-		EntityID: nil,
-		SdnName:  nil,
-		Type:     "",
-		Score:    -1.0, // -1.0 indicates nothing found
-		Programs: []string{},
-	}
-
-	ctx, cancelFunc := context.WithTimeout(context.TODO(), 5*time.Second)
-	defer cancelFunc()
-
-	search_result, resp, err := api.WatchmanApi.Search(ctx, opts)
-	if err != nil {
-		return empty_result, fmt.Errorf("searchByName: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if *flagVerbose {
-		log.Printf("[VERBOSE] search_result SDNs=%d; AltNames=%d", len(search_result.SDNs), len(search_result.AltNames))
-	}
-
-	// Return SDN if found
-	if len(search_result.SDNs) > 0 {
-		// Only return the best match
-		sdn := search_result.SDNs[0]
-		return newSearchResult(sdn, sdn.EntityID, float64(sdn.Match)), nil
-	}
-
-	//  If no SDN for name, check "customer" via EntityID
-	if len(search_result.AltNames) > 0 {
-		altEntityID := search_result.AltNames[0].EntityID
-		if *flagVerbose {
-			log.Printf("[VERBOSE] alternateName=%s; altEntityID=%s", search_result.AltNames[0].AlternateName, altEntityID)
-		}
-
-		customer_result, customer_resp, customer_err := api.WatchmanApi.GetOfacCustomer(ctx, altEntityID, &moov.GetOfacCustomerOpts{})
-		if customer_err != nil {
-			return empty_result, fmt.Errorf("searchByName: %v", err)
-		}
-		defer customer_resp.Body.Close()
-
-		if *flagVerbose {
-			log.Printf("[VERBOSE] customer_result=%v", customer_result.Sdn)
-		}
-
-		if customer_result.Sdn.EntityID == altEntityID {
-			return newSearchResult(customer_result.Sdn, altEntityID, float64(search_result.AltNames[0].Match)), nil
-		}
-	}
-
-	return empty_result, nil
 }

--- a/cmd/internal/search_batch.go
+++ b/cmd/internal/search_batch.go
@@ -1,0 +1,225 @@
+// Copyright 2022 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+// Extended by ComplyCo for batch searches
+
+package internal
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/antihax/optional"
+	"github.com/moov-io/base/log"
+	moov "github.com/moov-io/watchman/client"
+	"go4.org/syncutil"
+)
+
+var (
+	flagMinNameScore = flag.Float64("min-match", 0.90, "How close must names match")
+	flagRequestID    = flag.String("request-id", "", "Override what is set for the X-Request-ID HTTP header")
+	flagSdnType      = flag.String("sdn-type", "individual", "sdnType query param")
+	flagThreshold    = flag.Float64("threshold", 0.99, "Minimum match percentage required for blocking")
+)
+
+type ChanResult struct {
+	Index int
+	Value string
+}
+
+func ProcessRows(rows []string, api *moov.APIClient, log log.Logger) ([]string, error) {
+	log.Info().Log("Processing rows")
+	// First row is headers, store them
+	headings := rows[0]
+	rows = rows[1:]
+
+	var wg sync.WaitGroup
+	workers := syncutil.NewGate(runtime.NumCPU())
+	resultsChan := make(chan ChanResult, len(rows))
+	output := make([]string, len(rows)+1) // +1 for header row
+
+	for i, row := range rows {
+		wg.Add(1)
+		workers.Start()
+		go func(i int, row string) {
+			defer workers.Done()
+			defer wg.Done()
+
+			// Compose name from fixed columns - make smarter, later
+			cols := strings.Split(row, ",")
+			name := fmt.Sprintf("%s, %s", cols[2], cols[1])
+
+			if result, err := searchByName(api, name, log); err != nil {
+				log.Fatal().LogErrorf("[FATAL] problem searching for '%s': %v", name, err)
+				return
+			} else {
+				if result.IsSet {
+					log.Debug().Log(newSearchResultString(result, name))
+					resultsChan <- ChanResult{Value: newSearchResultRecord(result, row), Index: i}
+
+				} else {
+					log.Debug().Logf("[RESULT] no hits for %s", name)
+					resultsChan <- ChanResult{Value: newSearchResultClearRecord(result, row), Index: i}
+				}
+			}
+		}(i, row)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	output[0] = writeHeadings(headings)
+	for r := range resultsChan {
+		output[r.Index+1] = r.Value // +1 for header row
+	}
+	log.Debug().Logf("[SUCCESS] %d checks complete\n", len(rows))
+
+	return output, nil
+}
+
+func getNoun(score float64) string {
+	if score < 0.0 {
+		return "Clear"
+	}
+	if score >= *flagThreshold {
+		return "MATCH"
+	}
+	return "Hit"
+}
+
+func newSearchResultString(result moov.SearchResult, searched_name string) string {
+	return fmt.Sprintf(
+		"[RESULT] found %s for %s: SdnName=%s; EntityID=%s; Type=%s; Score=%.2f; Programs=%v; Remarks=%s; Timestamp=%s",
+		getNoun(result.Score),
+		searched_name,
+		*result.SdnName,
+		*result.EntityID,
+		result.Type,
+		result.Score,
+		result.Programs,
+		result.Remarks,
+		time.Now().Format(time.RFC3339),
+	)
+}
+
+func newSearchResultRecord(result moov.SearchResult, input_row string) string {
+	sdn_name_no_comma := *result.SdnName
+	if strings.Contains(*result.SdnName, ",") {
+		sdn_name_parts := strings.Split(*result.SdnName, ",")
+		sdn_name_no_comma = fmt.Sprintf("%s %s", sdn_name_parts[1], sdn_name_parts[0])
+	}
+
+	return fmt.Sprintf(
+		"%s,%s,%s,%s,%.2f,%s,%s",
+		strings.TrimRight(input_row, ","),
+		getNoun(result.Score),
+		sdn_name_no_comma,
+		*result.EntityID,
+		result.Score,
+		result.Programs,
+		time.Now().Format(time.RFC3339),
+	)
+}
+
+func newSearchResultClearRecord(result moov.SearchResult, searched_name string) string {
+	return fmt.Sprintf(
+		"%s,%s,,,,,%s",
+		strings.TrimRight(searched_name, ","),
+		getNoun(result.Score),
+		time.Now().Format(time.RFC3339),
+	)
+}
+
+func writeHeadings(original_headings string) string {
+	return fmt.Sprintf(
+		"%s,%s,%s,%s,%s,%s,%s",
+		strings.TrimRight(original_headings, ","),
+		"Result",
+		"SdnName",
+		"EntityID",
+		"Score",
+		"Programs",
+		"Timestamp",
+	)
+}
+
+func newSearchResult(query_result moov.OfacSdn, entity_id string, score float64) moov.SearchResult {
+	return moov.SearchResult{
+		IsSet:    true,
+		EntityID: &entity_id,
+		SdnName:  &query_result.SdnName,
+		Type:     query_result.SdnType,
+		Score:    score,
+		Programs: query_result.Programs,
+	}
+}
+
+/*
+ * Search OFAC data for given name.
+ * If no SDN but altNames, get data for each altName's EntityID.
+ *
+ * return SearchResult struct with: EntityID, SdnName, Type, Score, Programs
+ */
+func searchByName(api *moov.APIClient, name string, log log.Logger) (moov.SearchResult, error) {
+	opts := &moov.SearchOpts{
+		Limit:      optional.NewInt32(1),
+		Name:       optional.NewString(name),
+		MinMatch:   optional.NewFloat32(float32(*flagMinNameScore)),
+		SdnType:    optional.NewInterface(*flagSdnType),
+		XRequestID: optional.NewString(*flagRequestID),
+	}
+	empty_result := moov.SearchResult{
+		IsSet:    false,
+		EntityID: nil,
+		SdnName:  nil,
+		Type:     "",
+		Score:    -1.0, // -1.0 indicates nothing found
+		Programs: []string{},
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancelFunc()
+
+	search_result, resp, err := api.WatchmanApi.Search(ctx, opts)
+	if err != nil {
+		return empty_result, fmt.Errorf("cc_searchByName: %v", err)
+	}
+	defer resp.Body.Close()
+
+	log.Debug().Logf("[VERBOSE] search_result SDNs=%d; AltNames=%d", len(search_result.SDNs), len(search_result.AltNames))
+
+	// Return SDN if found
+	if len(search_result.SDNs) > 0 {
+		// Only return the best match
+		sdn := search_result.SDNs[0]
+		return newSearchResult(sdn, sdn.EntityID, float64(sdn.Match)), nil
+	}
+
+	//  If no SDN for name, check "customer" via EntityID
+	if len(search_result.AltNames) > 0 {
+		altEntityID := search_result.AltNames[0].EntityID
+		log.Debug().Logf("[VERBOSE] alternateName=%s; altEntityID=%s", search_result.AltNames[0].AlternateName, altEntityID)
+
+		customer_result, customer_resp, customer_err := api.WatchmanApi.GetOfacCustomer(ctx, altEntityID, &moov.GetOfacCustomerOpts{})
+		if customer_err != nil {
+			return empty_result, fmt.Errorf("cc_searchByName: %v", err)
+		}
+		defer customer_resp.Body.Close()
+
+		log.Debug().Logf("[VERBOSE] customer_result=%v", customer_result.Sdn)
+
+		if customer_result.Sdn.EntityID == altEntityID {
+			return newSearchResult(customer_result.Sdn, altEntityID, float64(search_result.AltNames[0].Match)), nil
+		}
+	}
+
+	return empty_result, nil
+}

--- a/cmd/internal/search_batch.go
+++ b/cmd/internal/search_batch.go
@@ -95,6 +95,8 @@ func setFlagsFromFormFields(r *http.Request) {
 	}
 	if sdn_type := r.FormValue("sdn-type"); sdn_type != "" {
 		*flagSdnType = sdn_type
+	} else {
+		*flagSdnType = "individual"
 	}
 	if request_id := r.FormValue("request-id"); request_id != "" {
 		*flagRequestID = request_id

--- a/cmd/server/search_handlers.go
+++ b/cmd/server/search_handlers.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-kit/kit/metrics/prometheus"
 	"github.com/gorilla/mux"
+	internal "github.com/moov-io/watchman/cmd/internal"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
@@ -37,6 +38,7 @@ func addSearchRoutes(logger log.Logger, r *mux.Router, searcher *searcher) {
 	r.Methods("GET").Path("/search/us-csl").HandlerFunc(searchUSCSL(logger, searcher))
 	r.Methods("GET").Path("/search/eu-csl").HandlerFunc(searchEUCSL(logger, searcher))
 	r.Methods("GET").Path("/search/uk-csl").HandlerFunc(searchUKCSL(logger, searcher))
+	r.Methods("POST").Path("/search/batch").HandlerFunc(internal.SearchBatch(logger))
 }
 
 func extractSearchLimit(r *http.Request) int {


### PR DESCRIPTION
There are two commits here:
  1. Refactor batch search CLI code, extract it for reuse in CLI and HTTP server
  2. Add function to HTTP server, call our batch search

**Test Plan**
1. Verify that CLI still works as previously:
```
% go run ./cmd/cc_batchsearch -file=/Users/trevorford/Projects/ofac/tests/post_input.csv -min-match=0.96 -threshold=0.99 -write
```
Here is the file: [post_input.csv](https://github.com/ComplyCo/watchman/files/13273612/post_input.csv)
The output file will be written to the same directory as the input file, named post_input_output.csv - or <original>_output.<original ext>

2. Run the server locally (remote coming soon!): `% make build && make run`
3. Send a POST request to `localhost:8084/search/batch`
   Add a param called "csvFile", change the type to File (please see screenshot below)

| Test case | Image |
| :--: | :--: |
| Defaults |<img width="1255" alt="Screenshot 2023-11-06 at 3 52 29 PM" src="https://github.com/ComplyCo/watchman/assets/122316787/1f561e5f-b81f-47ef-96af-dcc43e7ef957">|
| fuzzy=60% | <img width="1255" alt="Screenshot 2023-11-06 at 3 56 46 PM" src="https://github.com/ComplyCo/watchman/assets/122316787/ee41e09c-5cec-4056-b8ca-1b7df201ae78"> |
| fuzzy=60% threshold=70% | <img width="1255" alt="Screenshot 2023-11-06 at 3 58 35 PM" src="https://github.com/ComplyCo/watchman/assets/122316787/d23fa157-bc7f-4329-87ff-e58d42c00b25"> |
| sdn-type=Vessel | <img width="1255" alt="Screenshot 2023-11-06 at 4 12 31 PM" src="https://github.com/ComplyCo/watchman/assets/122316787/a8ad1116-89ee-4154-841d-11b4d7c8918c"> |