### PR TITLE
Fix handling for files under 300 rows, tweak text

### DIFF
--- a/webui/src/Form/index.js
+++ b/webui/src/Form/index.js
@@ -94,6 +94,10 @@ export default ({ onSubmit }) => {
     })
       .then(response => {
         if (response.ok) {
+          const warning = response.headers.get("X-Truncation-Warning");
+          if (warning != null) {
+            alert(warning);
+          }
           return response.text();
         } else {
           throw new Error("Request failed with status: " + response.status);
@@ -190,10 +194,10 @@ export default ({ onSubmit }) => {
           <h2>Instructions</h2>
           <p>
             <b>Minimum Name Score:</b> the fuzziness level for name matching<br/>
-            <b>Match Threshold:</b> the minimum score to be considered a match (vs a hit)<br/>
+            <b>Match Threshold:</b> above this is considered a match, below a hit<br/>
             <b>Type:</b> the SDN type to search for (individual, entity, vessel, aircraft, all)<br/>
           </p>
-          <p>Currently we only process the first <b>300</b> rows per file.</p>
+          <p>Currently we only process the first <b>301</b> rows (header row + 300 records).</p>
           <p>The input CSV file must contain at least three columns:</p>
           <ol>
             <li><i>anything</i></li>
@@ -214,7 +218,7 @@ export default ({ onSubmit }) => {
               {`123,Smith,John Jacob`}
             </code>
           </pre>
-          <p>Search results will be appended to each row and a new file will be downloaded.</p>
+          <p>Search results are appended to each row, a new file will be downloaded.</p>
         </Container>
       </TwoColumns>
     </Container>


### PR DESCRIPTION
I mindlessly truncated using a slice with literal integer 300, which only worked if there were more than 300 rows in the input file. This PR fixes that by taking the smaller value - number of rows in file or max_rows value.

I added a new command line parameter to change the max_rows value. By default it is 301 now (300 record rows + 1 header row).

**Test Plan**
1. Open https://fspu3irmny.us-east-2.awsapprunner.com
2. Test with Dmitry's post_input_2.csv file
3. Test with Ron's real test file (361 records)
4. Test on command line with Ron's file:
```
trevorford@Trevors-MacBook-Pro watchman % go run ./cmd/cc_batchsearch -file=/Users/trevorford/Projects/ofac/tests/I2C_Accounts_10-17-2023.csv -min-match=0.96 -threshold=0.99 -address=https://fspu3irmny.us-east-2.awsapprunner.com -local=false -max-rows=351 -write
ts=2023-11-10T06:24:43Z msg="Starting moov/batchsearch v0.24.2" level=info
ts=2023-11-10T06:24:43Z msg="[INFO] using https://fspu3irmny.us-east-2.awsapprunner.com for API address" level=info
ts=2023-11-10T06:24:44Z msg="[SUCCESS] ping" level=info
ts=2023-11-10T06:24:44Z msg="Processing 350 records" level=info
ts=2023-11-10T06:26:00Z msg="[SUCCESS] 350 checks complete\n" level=info
ts=2023-11-10T06:26:00Z msg="[INFO] ONLY PROCESSED 351 of 362 rows from file" level=info
```